### PR TITLE
add getEvents function to the BigQuery data provider

### DIFF
--- a/list-generators/generators/7_pooly-minters/index.ts
+++ b/list-generators/generators/7_pooly-minters/index.ts
@@ -1,0 +1,70 @@
+import { BigNumberish } from "ethers";
+import { ValueType, Tags, FetchedData } from "../../../src/list";
+import {
+  GenerationFrequency,
+  GeneratorContext,
+  ListGenerator,
+} from "../../../src/list-generator";
+import { List } from "../../../src/list/list";
+import BigQueryProvider from "../../helpers/providers/big-query/big-query";
+
+export default new ListGenerator({
+  id: 7,
+  name: "pooly-minters",
+  generate: async (context: GeneratorContext): Promise<List> => {
+    const bigQueryProvider = new BigQueryProvider();
+
+    const NFTMintedEventABI =
+      "event NFTMinted(address indexed to, uint256 numberOfTokens, uint256 amount)";
+    type NFTMintedType = {
+      to: string;
+      numberOfTokens: BigNumberish;
+      amount: BigNumberish;
+    };
+
+    const getPoolyMinters = async (
+      contractAddress: string
+    ): Promise<NFTMintedType[]> => {
+      return bigQueryProvider.getEvents<NFTMintedType>({
+        contractAddress,
+        eventABI: NFTMintedEventABI,
+        options: {
+          blockNumber: context.blockNumber,
+        },
+      });
+    };
+
+    const PoolySupporterAddress = "0x90b3832e2f2ade2fe382a911805b6933c056d6ed";
+    const PoolyLawyerAddress = "0x3545192b340f50d77403dc0a64cf2b32f03d00a9";
+    const PoolyJudgeAddress = "0x5663e3e096f1743e77b8f71b5de0cf9dfd058523";
+
+    const poolySupporterMinters = await getPoolyMinters(PoolySupporterAddress);
+    const poolyLawyerMinters = await getPoolyMinters(PoolyLawyerAddress);
+    const poolyJudgeMinters = await getPoolyMinters(PoolyJudgeAddress);
+
+    let data: FetchedData = {};
+    // Let's fill with the following value
+    // Pooly Support => 1
+    for (const address of poolySupporterMinters) {
+      data[address.to] = 1;
+    }
+
+    // Pooly Lawyer => 2
+    for (const address of poolyLawyerMinters) {
+      data[address.to] = 2;
+    }
+
+    // Pooly Judge => 3
+    for (const address of poolyJudgeMinters) {
+      data[address.to] = 3;
+    }
+
+    return new List({
+      generationDate: new Date(context.timestamp),
+      data,
+      valueType: ValueType.Score,
+      tags: [Tags.Mainnet, Tags.Asset, Tags.NFT],
+    });
+  },
+  generationFrequency: GenerationFrequency.Weekly,
+});

--- a/list-generators/generators/index.ts
+++ b/list-generators/generators/index.ts
@@ -4,6 +4,7 @@ import sismoPoap from "./3_sismo-POAPs";
 import sismoDomain from "./4_sismo-domains";
 import ethUsers from "./5_eth-users";
 import lensProfiles from "./6_lens-profiles";
+import poolyMinters from "./7_pooly-minters";
 
 const generators = [
   ethOwners,
@@ -12,6 +13,7 @@ const generators = [
   sismoDomain,
   ethUsers,
   lensProfiles,
+  poolyMinters,
 ];
 
 export default generators;

--- a/list-generators/helpers/providers/big-query/big-query.ts
+++ b/list-generators/helpers/providers/big-query/big-query.ts
@@ -1,5 +1,6 @@
 import { BigQuery } from "@google-cloud/bigquery";
-import { BigNumber, BigNumberish } from "ethers";
+import { BigNumber, BigNumberish, utils } from "ethers";
+import { Interface } from "ethers/lib/utils";
 import { FetchedData } from "../../../../src/list";
 
 type BigQueryProviderConstructor = {
@@ -21,6 +22,14 @@ type BigQueryNftOwnershipArgs = {
   blockNumber: number;
 };
 
+type BigQueryEventArgs = {
+  contractAddress: string;
+  eventABI: string;
+  options?: {
+    blockNumber: number;
+  };
+};
+
 export default class BigQueryProvider {
   chainId: number;
 
@@ -29,11 +38,16 @@ export default class BigQueryProvider {
   }
 
   public async authenticate() {
-    const credential = JSON.parse(process.env.GOOGLE_APPLICATION_CREDENTIALS!);
-    const bigqueryClient = new BigQuery({
-      projectId: credential.project_id,
-      credentials: credential,
-    });
+    const isLocal = process.env.NODE_ENV === "local";
+    const credential = !isLocal
+      ? JSON.parse(process.env.GOOGLE_APPLICATION_CREDENTIALS!)
+      : null;
+    const bigqueryClient = !isLocal
+      ? new BigQuery({
+          projectId: credential.project_id,
+          credentials: credential,
+        })
+      : new BigQuery();
     return bigqueryClient;
   }
 
@@ -80,7 +94,7 @@ export default class BigQueryProvider {
     WITH token AS (
         SELECT * FROM \`bigquery-public-data.crypto_ethereum.token_transfers\`
         WHERE token_address='${contractAddress.toLowerCase()}'
-        ${blockNumber ? `AND block_number < ${blockNumber}` : ""}
+        ${blockNumber ? `AND block_number <= ${blockNumber}` : ""}
       ),
       token_received AS (
         SELECT to_address AS address, COUNT(to_address) AS nb FROM token group by to_address
@@ -118,5 +132,39 @@ export default class BigQueryProvider {
         `;
     const accountsData = await this.fetch(query);
     return accountsData;
+  }
+
+  public async getEvents<T>({
+    contractAddress,
+    eventABI,
+    options,
+  }: BigQueryEventArgs): Promise<T[]> {
+    const bigqueryClient = await this.authenticate();
+    const iface = new Interface([eventABI]);
+
+    // construct the event signature
+    const eventSignature = utils.id(
+      `${iface.fragments[0].name}(${iface.fragments[0].inputs
+        .map((x) => x.type)
+        .join(",")})`
+    );
+
+    // filter the event directly in the query using the eventSignature
+    const query = `
+    SELECT data, topics FROM \`bigquery-public-data.crypto_ethereum.logs\` 
+    WHERE address="${contractAddress}"
+    ${options?.blockNumber ? `AND block_number <= ${options.blockNumber}` : ""}
+    AND topics[OFFSET(0)] LIKE '%${eventSignature}%';
+    `;
+    const response = await bigqueryClient.query(query);
+
+    // decode the event using the data and topics fields
+    return response[0].map(
+      (event) =>
+        iface.parseLog({
+          topics: event.topics,
+          data: event.data,
+        }).args as any as T
+    );
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "scripts": {
     "test": "npx jest --runInBand",
-    "generate:list": "LOG=true node --max_old_space_size=4096 --require ts-node/register src/scripts/generate-list.ts",
+    "generate:list": "NODE_ENV=local LOG=true node --max_old_space_size=4096 --require ts-node/register src/scripts/generate-list.ts",
     "lint": "eslint src/**/*.ts --max-warnings=0"
   },
   "devDependencies": {

--- a/src/scripts/generate-list.ts
+++ b/src/scripts/generate-list.ts
@@ -4,7 +4,7 @@ import {
   GenerationContext,
 } from "../../src/utils/generation-context";
 import readline from "readline";
-import { storeOnDisk } from "../utils/disk"
+import { storeOnDisk } from "../utils/disk";
 
 createContext().then(async (generationContext: GenerationContext) => {
   const generatorName = process.argv[2];
@@ -23,6 +23,6 @@ createContext().then(async (generationContext: GenerationContext) => {
   const name = generationContext.timestamp.toString();
   await storeOnDisk(name, list, generatorName);
   readline.clearLine(process.stdout, 0);
-  console.log(`List generated in /tmp/${generatorName}/${name}`);
+  console.log(`List generated in ./tmp/${generatorName}/${name}.json`);
   process.exit(0);
 });


### PR DESCRIPTION
Add the getEvents function to the BigQuery data provider.
This function allows to get all events that match a given event ABI.
It uses custom typing template for easier developement with the query response.

Example:
```typescript
// Declare the event ABI
const NFTMintedEventABI =
  "event NFTMinted(address indexed to, uint256 numberOfTokens, uint256 amount)";

// Declare your type
type NFTMintedType = {
  to: string;
  numberOfTokens: BigNumberish;
  amount: BigNumberish;
};

// Call the getEvents function
// the result will be a NFTMintedType[] type. 
mintedEvents = await bigQueryProvider.getEvents<NFTMintedType>({
  contractAddress,
  eventABI: NFTMintedEventABI,
  options: {
    blockNumber: context.blockNumber,
  },
});

// Use NFTMintedType[] type in the response:
const minterAddresses = mintedEvents.map(mintedEvent => mintedEvent.to);
```

A real application is available at the pooly minters list generator:
`/list-generators/generators/7_pooly-minters/index.ts`