### PR TITLE
fix: run eslint recursivly

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "test": "npx jest --runInBand",
     "generate:group": "NODE_ENV=local  LOG=true node --max_old_space_size=4096 --require ts-node/register src/scripts/generate-group.ts",
-    "lint": "eslint src/**/*.ts --max-warnings=0"
+    "lint": "eslint 'src/**/*.ts' --max-warnings=0"
   },
   "devDependencies": {
     "@types/jest": "^27.5.1",

--- a/src/helpers/utils/store-data.ts
+++ b/src/helpers/utils/store-data.ts
@@ -1,6 +1,3 @@
-import AWS from "aws-sdk";
-const s3 = new AWS.S3();
-
 export type DataStoreReference = {
   hash: string;
   type: "S3" | "Disk";


### PR DESCRIPTION
globstar `**` is not default and is disabled by default. Here, we use
eslint for globbing.